### PR TITLE
Fix log message in generate script

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
 	<title>Unbang</title>
 	<meta name="description" content="Your personal search engine (with bangs!)" />
 
-	<script defer src="https://analytics.whatthefreakisthis.com/alyt" data-website-id="3bd2eda4-d055-4acd-8253-8b9fea29d132"></script></head>
+	<script defer src="https://analytics.whatthefreakisthis.com/alyt" data-website-id="3bd2eda4-d055-4acd-8253-8b9fea29d132"></script>
 </head>
 
 <body>

--- a/scripts/generate-bangs.js
+++ b/scripts/generate-bangs.js
@@ -14,7 +14,7 @@ async function build() {
 
   const outPath = join(process.cwd(), 'src/bangs.json');
   await writeFile(outPath, JSON.stringify(bangs, null, 2) + '\n', 'utf8');
-  console.log(`✓ wrote ${bangs.length} bangs to src/main.json`);
+  console.log(`✓ wrote ${bangs.length} bangs to src/bangs.json`);
 }
 
 build().catch(err => {


### PR DESCRIPTION
## Summary
- fix the output log path in `generate-bangs.js`

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a274671f48320a751ffb8fd77f0fc